### PR TITLE
Fix of appendix listings numeration

### DIFF
--- a/template_settings/Dissertation/disstyles.tex
+++ b/template_settings/Dissertation/disstyles.tex
@@ -515,6 +515,7 @@
 	\renewcommand{\thesubsubsection}{\thesubsection.\arabic{subsubsection}}
 	\counterwithin{footnote}{chapter} %связанная нумерация глав-сносок
 	\renewcommand{\thefootnote}{П\thechapter.\arabic{footnote}}
+	\renewcommand{\thelstlisting}{П\thechapter.\arabic{lstlisting}}
 }
 
 


### PR DESCRIPTION
При использовании пакета `listings` в приложении, делает нумерацию листингов вида `Листинг П1.1`, а не `Листинг 1.1`

До:
![image](https://user-images.githubusercontent.com/20727983/84802693-a2c16900-b009-11ea-8d12-329b4ea3aae3.png)

После:
![image](https://user-images.githubusercontent.com/20727983/84802144-d94ab400-b008-11ea-8eda-c9e1d878a50d.png)
